### PR TITLE
Feature/split intervals

### DIFF
--- a/pitci/__init__.py
+++ b/pitci/__init__.py
@@ -8,6 +8,7 @@ import pitci.helpers as helpers
 from pitci.dispatchers import (
     get_leaf_node_scaled_conformal_predictor,
     get_absolute_error_conformal_predictor,
+    get_leaf_node_split_conformal_predictor,
 )
 
 try:

--- a/pitci/_version.py
+++ b/pitci/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.2.dev2"
+__version__ = "0.1.2.dev3"

--- a/pitci/base.py
+++ b/pitci/base.py
@@ -196,9 +196,10 @@ class LeafNodeScaledConformalPredictor(ABC):
     leaf_node_counts: list
 
     @abstractmethod
-    def __init__(self) -> None:
+    def __init__(self, model: Any) -> None:
 
         self.__version__ = __version__
+        self.model = model
 
     def calibrate(
         self,

--- a/pitci/dispatchers.py
+++ b/pitci/dispatchers.py
@@ -23,3 +23,14 @@ def get_leaf_node_scaled_conformal_predictor(model):
     raise NotImplementedError(
         f"model type not supported for LeafNodeScaledConformalPredictor children; {type(model)}"
     )
+
+
+@singledispatch
+def get_leaf_node_split_conformal_predictor(model):
+    """Function to return the appropriate child class of
+    SplitConformalPredictor depending on the type of the model arg.
+    """
+
+    raise NotImplementedError(
+        f"model type not supported for SplitConformalPredictor children; {type(model)}"
+    )

--- a/pitci/lightgbm.py
+++ b/pitci/lightgbm.py
@@ -17,6 +17,7 @@ from pitci.base import LeafNodeScaledConformalPredictor, SplitConformalPredictor
 from pitci.checks import check_type, check_allowed_value
 from pitci.dispatchers import (
     get_leaf_node_scaled_conformal_predictor,
+    get_leaf_node_split_conformal_predictor,
 )
 
 
@@ -249,5 +250,18 @@ def return_lgb_booster_leaf_node_scaled_confromal_predictor(
     """
 
     confo_model = LGBMBoosterLeafNodeScaledConformalPredictor(model=model)
+
+    return confo_model
+
+
+@get_leaf_node_split_conformal_predictor.register(lgb.basic.Booster)
+def return_lgb_booster_leaf_node_split_confromal_predictor(
+    model: lgb.Booster,
+) -> LGBMBoosterLeafNodeSplitConformalPredictor:
+    """Function to return an instance of LGBMBoosterLeafNodeSplitConformalPredictor
+    class the passed lgb.Booster object.
+    """
+
+    confo_model = LGBMBoosterLeafNodeSplitConformalPredictor(model=model)
 
     return confo_model

--- a/pitci/lightgbm.py
+++ b/pitci/lightgbm.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError as err:
 
 from typing import List, Union, Any
 
-from pitci.base import LeafNodeScaledConformalPredictor
+from pitci.base import LeafNodeScaledConformalPredictor, SplitConformalPredictor
 from pitci.checks import check_type, check_allowed_value
 from pitci.dispatchers import (
     get_leaf_node_scaled_conformal_predictor,
@@ -212,6 +212,32 @@ class LGBMBoosterLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredict
             )
 
         return leaf_node_predictions
+
+
+class LGBMBoosterLeafNodeSplitConformalPredictor(
+    SplitConformalPredictor, LGBMBoosterLeafNodeScaledConformalPredictor
+):
+    """Conformal interval predictor for an underlying `lgb.Booster`
+    model using scaled and split absolute error as the nonconformity measure.
+
+    The predictor outputs varying width intervals for every new instance.
+    The scaling function uses the number of times that the leaf nodes were
+    visited for each tree in making the prediction, for that row, were
+    visited in the calibration dataset.
+
+    Intervals are split into bins, using the scaling factors, where each bin
+    is calibrated at the required confidence level. This addresses the
+    situation that `LGBMBoosterLeafNodeScaledConformalPredictor` can encounter
+    where the intervals are calibrated at the overall level for a given
+    dataset but subsets of the data are not well calibrated.
+
+    This class combines the methods implemented in SplitConformalPredictor and
+    LGBMBoosterLeafNodeScaledConformalPredictor so nothing else is required to
+    be implemented in the child class itself.
+
+    """
+
+    pass
 
 
 @get_leaf_node_scaled_conformal_predictor.register(lgb.basic.Booster)

--- a/pitci/lightgbm.py
+++ b/pitci/lightgbm.py
@@ -116,15 +116,13 @@ class LGBMBoosterLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredict
 
     def __init__(self, model: lgb.Booster) -> None:
 
-        super().__init__()
-
         check_type(model, [lgb.basic.Booster], "model")
+
+        super().__init__(model=model)
 
         self.SUPPORTED_OBJECTIVES = SUPPORTED_OBJECTIVES_ABS_ERROR
 
         check_objective_supported(model, self.SUPPORTED_OBJECTIVES)
-
-        self.model = model
 
     def _calibrate_leaf_node_counts(self, data: Any) -> None:
         """Method to get the number of times each leaf node was visited on the training

--- a/pitci/xgboost.py
+++ b/pitci/xgboost.py
@@ -365,13 +365,11 @@ class XGBoosterLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredictor
 
         check_type(model, [xgb.Booster], "model")
 
+        super().__init__(model=model)
+
         self.SUPPORTED_OBJECTIVES = SUPPORTED_OBJECTIVES_ABS_ERROR
 
         check_objective_supported(model, self.SUPPORTED_OBJECTIVES)
-
-        self.model = model
-
-        super().__init__()
 
     def calibrate(
         self,
@@ -605,13 +603,11 @@ class XGBSklearnLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredicto
 
         check_type(model, [xgb.XGBRegressor, xgb.XGBClassifier], "model")
 
+        super().__init__(model=model)
+
         self.SUPPORTED_OBJECTIVES = SUPPORTED_OBJECTIVES_ABS_ERROR
 
         check_objective_supported(model.get_booster(), self.SUPPORTED_OBJECTIVES)
-
-        self.model = model
-
-        LeafNodeScaledConformalPredictor.__init__(self)
 
     def calibrate(
         self,

--- a/pitci/xgboost.py
+++ b/pitci/xgboost.py
@@ -23,6 +23,7 @@ from pitci.checks import check_type, check_allowed_value
 from pitci.dispatchers import (
     get_leaf_node_scaled_conformal_predictor,
     get_absolute_error_conformal_predictor,
+    get_leaf_node_split_conformal_predictor,
 )
 
 
@@ -858,5 +859,18 @@ def return_xgb_sklearn_leaf_node_scaled_confromal_predictor(
     """
 
     confo_model = XGBSklearnLeafNodeScaledConformalPredictor(model=model)
+
+    return confo_model
+
+
+@get_leaf_node_split_conformal_predictor.register(xgb.Booster)
+def return_xgb_booster_leaf_node_split_confromal_predictor(
+    model: xgb.Booster,
+) -> XGBoosterLeafNodeSplitConformalPredictor:
+    """Function to return an instance of XGBoosterLeafNodeSplitConformalPredictor
+    class the passed xgb.Booster object.
+    """
+
+    confo_model = XGBoosterLeafNodeSplitConformalPredictor(model=model)
 
     return confo_model

--- a/pitci/xgboost.py
+++ b/pitci/xgboost.py
@@ -14,7 +14,11 @@ except ModuleNotFoundError as err:
 
 from typing import Union, Optional, List, cast
 
-from pitci.base import AbsoluteErrorConformalPredictor, LeafNodeScaledConformalPredictor
+from pitci.base import (
+    AbsoluteErrorConformalPredictor,
+    LeafNodeScaledConformalPredictor,
+    SplitConformalPredictor,
+)
 from pitci.checks import check_type, check_allowed_value
 from pitci.dispatchers import (
     get_leaf_node_scaled_conformal_predictor,
@@ -776,6 +780,32 @@ class XGBSklearnLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredicto
             leaf_node_predictions = leaf_node_predictions.reshape((data.shape[0], 1))
 
         return leaf_node_predictions
+
+
+class XGBoosterLeafNodeSplitConformalPredictor(
+    SplitConformalPredictor, XGBoosterLeafNodeScaledConformalPredictor
+):
+    """Conformal interval predictor for an underlying `xgboost.Booster`
+    model using scaled and split absolute error as the nonconformity measure.
+
+    The predictor outputs varying width intervals for every new instance.
+    The scaling function uses the number of times that the leaf nodes were
+    visited for each tree in making the prediction, for that row, were
+    visited in the calibration dataset.
+
+    Intervals are split into bins, using the scaling factors, where each bin
+    is calibrated at the required confidence level. This addresses the
+    situation that `XGBoosterLeafNodeScaledConformalPredictor` can encounter
+    where the intervals are calibrated at the overall level for a given
+    dataset but subsets of the data are not well calibrated.
+
+    This class combines the methods implemented in SplitConformalPredictor and
+    XGBoosterLeafNodeScaledConformalPredictor so nothing else is required to
+    be implemented in the child class itself.
+
+    """
+
+    pass
 
 
 @get_absolute_error_conformal_predictor.register(xgb.Booster)

--- a/pitci/xgboost.py
+++ b/pitci/xgboost.py
@@ -443,13 +443,13 @@ class XGBoosterLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredictor
 
         if train_data is None:
 
-            super()._calibrate_leaf_node_counts(data=data)
+            self._calibrate_leaf_node_counts(data=data)
 
         else:
 
-            super()._calibrate_leaf_node_counts(data=train_data)
+            self._calibrate_leaf_node_counts(data=train_data)
 
-        super()._calibrate_interval(data=data, alpha=alpha, response=response)
+        self._calibrate_interval(data=data, alpha=alpha, response=response)
 
     def predict_with_interval(self, data: xgb.DMatrix) -> np.ndarray:
         """Method to generate predictions on data with conformal intervals.

--- a/tests/base/test_LeafNodeScaledConformalPredictor.py
+++ b/tests/base/test_LeafNodeScaledConformalPredictor.py
@@ -14,12 +14,12 @@ class DummyLeafNodeScaledConformalPredictor(LeafNodeScaledConformalPredictor):
     functionality can be tested.
     """
 
-    def __init__(self):
+    def __init__(self, model="abcd"):
         """Dummy init method that only calls LeafNodeScaledConformalPredictor
         init method.
         """
 
-        super().__init__()
+        super().__init__(model=model)
 
     def _generate_predictions(self, data):
         """Dummy function that returns 0s of shape (n,) where data has n rows."""
@@ -48,6 +48,13 @@ class TestInit:
         assert (
             dummy_confo_model.__version__ == pitci.__version__
         ), "version attribute not set correctly"
+
+    def test_model_attribute_set(self):
+        """Test that the object passed in the model arg is set to the model attribute."""
+
+        dummy_confo_model = DummyLeafNodeScaledConformalPredictor(model=1)
+
+        assert dummy_confo_model.model == 1, "model attribute not set correctly"
 
 
 class TestCalibrate:

--- a/tests/base/test_SplitConformalPredictor.py
+++ b/tests/base/test_SplitConformalPredictor.py
@@ -1,0 +1,334 @@
+import numpy as np
+import re
+
+from pitci.base import SplitConformalPredictor
+import pitci
+
+import pytest
+
+
+class DummySplitConformalPredictor(SplitConformalPredictor):
+    """Dummy class inheriting from SplitConformalPredictor so it's
+    functionality can be tested.
+    """
+
+    def __init__(self, model="abcd", n_bins=3):
+        """Dummy init method that only calls SplitConformalPredictor
+        init method.
+        """
+
+        super().__init__(model=model, n_bins=n_bins)
+
+    def _generate_predictions(self, data):
+        """Dummy function that returns 0s of shape (n,) where data has n rows."""
+
+        return np.zeros(data.shape[0])
+
+    def _generate_leaf_node_predictions(self, data):
+        """Dummy function for returning leaf node index predictions, not implemented in
+        DummySplitConformalPredictor so it has to be implemented specifically in
+        each test requiring it.
+        """
+
+        raise NotImplementedError(
+            "_generate_leaf_node_predictions not implemented in SplitConformalPredictor"
+        )
+
+
+class TestInit:
+    """Tests for the SplitConformalPredictor.__init__ method."""
+
+    def test_n_bins_not_int_error(self):
+        """Test an exception is raised if n_bins is not an int."""
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(f"n_bins is not in expected types {[int]}, got {str}"),
+        ):
+
+            DummySplitConformalPredictor(n_bins="a")
+
+    def test_n_bins_not_greater_than_one_error(self):
+        """Test an exception is raised if n_bins is not greater than 1."""
+
+        with pytest.raises(ValueError, match="n_bins should be greater than 1"):
+
+            DummySplitConformalPredictor(n_bins=1)
+
+    def test_bin_attributes_set(self):
+        """Test that n_bins and bin_quantiles attributes are set in init."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=15)
+
+        assert dummy_confo_model.n_bins == 15, "n_bins attribute not set correctly"
+
+        np.testing.assert_array_equal(
+            dummy_confo_model.bin_quantiles, np.linspace(0, 1, 16)
+        )
+
+
+class TestCalibrateInterval:
+    """Tests for the SplitConformalPredictor._calibrate_interval method."""
+
+    def test_exception_no_leaf_node_counts(self):
+        """Test an exception is raised if no leaf_node_counts atttibute is present."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=5)
+
+        assert not hasattr(dummy_confo_model, "leaf_node_counts")
+
+        with pytest.raises(
+            AttributeError,
+            match="object does not have leaf_node_counts attribute, run calibrate first.",
+        ):
+
+            dummy_confo_model._calibrate_interval(np.array([1, 0]), np.array([1, 0]))
+
+    @pytest.mark.parametrize(
+        "n_bins, scaling_factors, expected_scaling_factor_cut_points",
+        [
+            (2, np.array([1, 0, 2, 4, 5, 3]), np.array([0, 2.5, 5])),
+            (3, np.array([6, 1, 0, 2, 4, 5, 3]), np.array([0, 2, 4, 6])),
+            (
+                4,
+                np.array([6, 1, 0, 2, 4, 5, 3, 7, 8, 9, 10]),
+                np.array([0, 2.5, 5, 7.5, 10]),
+            ),
+        ],
+    )
+    def test_scaling_factor_cut_points_expected(
+        self, mocker, n_bins, scaling_factors, expected_scaling_factor_cut_points
+    ):
+        """Test that scaling_factor_cut_points attribute is calculated as expected."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=n_bins)
+        dummy_confo_model.leaf_node_counts = {}
+
+        data = np.array([1, 0])
+        response = np.zeros(scaling_factors.shape)
+        predictions = np.zeros(scaling_factors.shape)
+
+        # set return value from _generate_predictions
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_generate_predictions",
+            return_value=predictions,
+        )
+
+        # set return value from _calculate_scaling_factors
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_calculate_scaling_factors",
+            return_value=scaling_factors,
+        )
+
+        dummy_confo_model._calibrate_interval(data=data, response=response)
+
+        np.testing.assert_array_equal(
+            dummy_confo_model.scaling_factor_cut_points,
+            expected_scaling_factor_cut_points,
+        )
+
+    def test_baseline_intervals_expected(self, mocker):
+        """Test that baseline_intervals attribute is calculated as expected."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=5)
+        dummy_confo_model.leaf_node_counts = {}
+
+        scaling_factors = np.array([i for i in range(101)])
+
+        data = np.array([1, 0])
+        response = np.zeros(scaling_factors.shape)
+        predictions = np.zeros(scaling_factors.shape)
+
+        nonconformity_values = np.array([i for i in range(100, 201)])
+
+        # set return value from _generate_predictions
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_generate_predictions",
+            return_value=predictions,
+        )
+
+        # set return value from _calculate_scaling_factors
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_calculate_scaling_factors",
+            return_value=scaling_factors,
+        )
+
+        # set return value from _generate_predictions
+        mocker.patch.object(
+            pitci.nonconformity,
+            "scaled_absolute_error",
+            return_value=nonconformity_values,
+        )
+
+        dummy_confo_model._calibrate_interval(data=data, response=response, alpha=0.8)
+
+        expected_scaling_factor_cut_points = np.array(
+            [0.0, 20.0, 40.0, 60.0, 80.0, 100.0]
+        )
+
+        np.testing.assert_array_almost_equal(
+            dummy_confo_model.scaling_factor_cut_points,
+            expected_scaling_factor_cut_points,
+        )
+
+        # in terms of bins that the nonconformity_values fall into
+        # the first bin will contain values [100:120], the second [121:140]
+        # the third [141:160] and so on up to 5 bins
+        # each bin has the 80th percentile calculated which give
+        # the values below
+        expected_baseline_intervals = np.array([116, 136.2, 156.2, 176.2, 196.2])
+
+        np.testing.assert_array_equal(
+            dummy_confo_model.baseline_intervals, expected_baseline_intervals
+        )
+
+
+class TestPredictWithInterval:
+    """Tests for the LeafNodeScaledConformalPredictor.predict_with_interval method."""
+
+    def test_exception_no_baseline_interval(self):
+        """Test an exception is raised if no baseline_intervals atttibute is present."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=5)
+
+        assert not hasattr(dummy_confo_model, "baseline_intervals")
+
+        with pytest.raises(
+            AttributeError,
+            match="object does not have baseline_intervals attribute, run calibrate first.",
+        ):
+
+            dummy_confo_model.predict_with_interval(np.array([1, 0]))
+
+    def test_expected_output(self, mocker):
+        """Test the intervals returned are calculated as predictions +-
+        (scaling factor * baseline interval).
+        """
+
+        dummy_confo_model = DummySplitConformalPredictor()
+
+        dummy_confo_model.baseline_intervals = 2
+
+        # set return value from _generate_predictions
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_generate_predictions",
+            return_value=np.array([-4, 0, 1, 4]),
+        )
+
+        # set return value from _generate_predictions
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_calculate_scaling_factors",
+            return_value=np.array([0.5, 1, 2, -2]),
+        )
+
+        # set return value from _lookup_baseline_interval
+        mocker.patch.object(
+            DummySplitConformalPredictor,
+            "_lookup_baseline_interval",
+            return_value=np.array([0, 0.5, 4, 10]),
+        )
+
+        results = dummy_confo_model.predict_with_interval(np.array([1, 0, -1]))
+
+        expected_results = np.array(
+            [[-4, -4, -4], [-0.5, 0, 0.5], [-7, 1, 9], [24, 4, -16]]
+        )
+
+        np.testing.assert_array_equal(results, expected_results)
+
+
+class TestLookupBaselineInterval:
+    """Tests for the SplitConformalPredictor._lookup_baseline_interval method."""
+
+    def test_correct_interval_lookuped_up(self):
+        """Test that the correct value from baseline_intervals is returned."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=4)
+
+        dummy_confo_model.baseline_intervals = np.array([2, 4, 6, 8])
+        dummy_confo_model.scaling_factor_cut_points = np.array([-10, 0, 10, 20, 30])
+
+        s = 0.00000001
+
+        lookup_scaling_factor_values = np.array(
+            [
+                -11,
+                -10 - s,
+                -10,
+                -10 + s,
+                -5,
+                0 - s,
+                0,
+                0 + s,
+                5,
+                10 - s,
+                10,
+                10 + s,
+                15,
+                20 - s,
+                20,
+                20 + s,
+                25,
+                30 - s,
+                30,
+                30 + s,
+                35,
+            ]
+        )
+
+        expected_looked_up_intervals = np.array(
+            [2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8]
+        )
+
+        looked_up_intervals = dummy_confo_model._lookup_baseline_interval(
+            lookup_scaling_factor_values
+        )
+
+        np.testing.assert_array_equal(expected_looked_up_intervals, looked_up_intervals)
+
+
+class TestCheckIntervalMonotonicity:
+    """Tests for the SplitConformalPredictor._check_interval_monotonicity method."""
+
+    @pytest.mark.parametrize(
+        "baseline_intervals",
+        [(np.array([1, 2, 3, 4, 3])), (np.array([1, 0.2, 3, 4, 300]))],
+    )
+    def test_warning_raised(self, baseline_intervals):
+        """Test the correct warning is raised if baseline_intervals are not monotonic."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=4)
+
+        dummy_confo_model.baseline_intervals = baseline_intervals
+
+        with pytest.warns(
+            Warning,
+            match="baseline intervals calculated on 4 bins are not monotonic in either direction",
+        ):
+
+            dummy_confo_model._check_interval_monotonicity()
+
+    @pytest.mark.parametrize(
+        "baseline_intervals",
+        [(np.array([0.1, 0.2, 0.3, 0.4, 20])), (np.array([-1, -2, -3, -4, -300]))],
+    )
+    def test_no_warnings_when_monotonic(self, baseline_intervals):
+        """Test no warnings are raised when baseline_intervals are monotonic."""
+
+        dummy_confo_model = DummySplitConformalPredictor(n_bins=6)
+
+        dummy_confo_model.baseline_intervals = baseline_intervals
+
+        with pytest.warns(None) as warnings:
+
+            dummy_confo_model._check_interval_monotonicity()
+
+        assert (
+            len(warnings) == 0
+        ), "warnings were raised when baseline_intervals were monotonic"

--- a/tests/lightgbm/test_LGBMBoosterLeafNodeScaledConformalPredictor.py
+++ b/tests/lightgbm/test_LGBMBoosterLeafNodeScaledConformalPredictor.py
@@ -101,9 +101,9 @@ class TestInit:
             call_pos_args == ()
         ), "positional args in LeafNodeScaledConformalPredictor.__init__ call not correct"
 
-        assert (
-            call_kwargs == {}
-        ), "keyword args in LeafNodeScaledConformalPredictor.__init__ call not correct"
+        assert call_kwargs == {
+            "model": lgb_booster_1_split_1_tree
+        }, "keyword args in LeafNodeScaledConformalPredictor.__init__ call not correct"
 
 
 class TestCalibrateLeafNodeCounts:

--- a/tests/lightgbm/test_LGBMBoosterLeafNodeSplitConformalPredictor.py
+++ b/tests/lightgbm/test_LGBMBoosterLeafNodeSplitConformalPredictor.py
@@ -1,0 +1,23 @@
+import abc
+
+from pitci.lightgbm import LGBMBoosterLeafNodeSplitConformalPredictor
+import pitci
+
+
+def test_mro():
+    """Test the inheritance order is correct."""
+
+    expected_mro = tuple(
+        [
+            pitci.lightgbm.LGBMBoosterLeafNodeSplitConformalPredictor,
+            pitci.base.SplitConformalPredictor,
+            pitci.lightgbm.LGBMBoosterLeafNodeScaledConformalPredictor,
+            pitci.base.LeafNodeScaledConformalPredictor,
+            abc.ABC,
+            object,
+        ]
+    )
+
+    assert (
+        LGBMBoosterLeafNodeSplitConformalPredictor.__mro__ == expected_mro
+    ), "mro not correct for LGBMBoosterLeafNodeSplitConformalPredictor"

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -162,3 +162,55 @@ class TestGetLeafNodeScaledConformalPredictor:
         ):
 
             dispatchers.get_leaf_node_scaled_conformal_predictor(1.1)
+
+
+class TestGetLeafNodeSplitConformalPredictor:
+    """Tests for the get_leaf_node_split_conformal_predictor function."""
+
+    def test_xgb_booster(self, xgboost_1_split_1_tree):
+        """Test an XGBoosterLeafNodeSplitConformalPredictor object is returned if
+        and xgb.Booster is passed.
+        """
+
+        confo_model = dispatchers.get_leaf_node_split_conformal_predictor(
+            xgboost_1_split_1_tree
+        )
+
+        assert (
+            type(confo_model) is pitci_xgb.XGBoosterLeafNodeSplitConformalPredictor
+        ), "incorrect type returned from get_leaf_node_split_conformal_predictor"
+
+        assert confo_model.model is xgboost_1_split_1_tree, (
+            "passed model arg not set to model attribute of object returned "
+            "from get_leaf_node_scaled_conformal_predictor"
+        )
+
+    def test_lgb_booster(self, lgb_booster_1_split_1_tree):
+        """Test an LGBMBoosterLeafNodeSplitConformalPredictor object is returned if
+        and lgb.Booster is passed.
+        """
+
+        confo_model = dispatchers.get_leaf_node_split_conformal_predictor(
+            lgb_booster_1_split_1_tree
+        )
+
+        assert (
+            type(confo_model) is pitci_lgb.LGBMBoosterLeafNodeSplitConformalPredictor
+        ), "incorrect type returned from get_leaf_node_split_conformal_predictor"
+
+        assert confo_model.model is lgb_booster_1_split_1_tree, (
+            "passed model arg not set to model attribute of object returned "
+            "from get_leaf_node_split_conformal_predictor"
+        )
+
+    def test_other_type_exception(self):
+        """Test an exception is raised if a non-implemented type is passed."""
+
+        with pytest.raises(
+            NotImplementedError,
+            match=re.escape(
+                f"model type not supported for SplitConformalPredictor children; {float}"
+            ),
+        ):
+
+            dispatchers.get_leaf_node_split_conformal_predictor(1.1)

--- a/tests/xgboost/test_XGBoosterLeafNodeSplitConformalPredictor.py
+++ b/tests/xgboost/test_XGBoosterLeafNodeSplitConformalPredictor.py
@@ -1,0 +1,23 @@
+import abc
+
+from pitci.xgboost import XGBoosterLeafNodeSplitConformalPredictor
+import pitci
+
+
+def test_mro():
+    """Test the inheritance order is correct."""
+
+    expected_mro = tuple(
+        [
+            pitci.xgboost.XGBoosterLeafNodeSplitConformalPredictor,
+            pitci.base.SplitConformalPredictor,
+            pitci.xgboost.XGBoosterLeafNodeScaledConformalPredictor,
+            pitci.base.LeafNodeScaledConformalPredictor,
+            abc.ABC,
+            object,
+        ]
+    )
+
+    assert (
+        XGBoosterLeafNodeSplitConformalPredictor.__mro__ == expected_mro
+    ), "mro not correct for XGBoosterLeafNodeSplitConformalPredictor"


### PR DESCRIPTION
- add `SplitConformalPredictor` class that allows conformal intervals to be calibrated for different bands based off the scaling factor
- add `XGBoosterLeafNodeSplitConformalPredictor` and `LGBMBoosterLeafNodeSplitConformalPredictor` classes that allow split conformal intervals with `xgb.Booster` and `lgb.Booster` objects where the scaling factor is based off the leaf node counts
- add tests for new functionality